### PR TITLE
Update fastlane-plugin-tpa.gemspec

### DIFF
--- a/fastlane-plugin-tpa.gemspec
+++ b/fastlane-plugin-tpa.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = %q{morten@justabeech.com}
 
   spec.summary       = %q{TPA gives you advanced user behaviour analytics, app distribution, crash analytics and more}
-  # spec.homepage      = "https://github.com/<GITHUB_USERNAME>/fastlane-plugin-tpa"
+  spec.homepage      = "https://github.com/mbogh/fastlane-plugin-tpa"
   spec.license       = "MIT"
 
   spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE)


### PR DESCRIPTION
In order to be properly linked from <https://github.com/neonichu/fastlane/blob/b81a6c9caf1eb7d89807bca9865df9d16877dcef/fastlane/docs/AvailablePlugins.md>, `spec.homepage` should be defined.