### PR TITLE
Publish as default

### DIFF
--- a/lib/fastlane/plugin/tpa/actions/tpa_action.rb
+++ b/lib/fastlane/plugin/tpa/actions/tpa_action.rb
@@ -115,7 +115,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :publish,
                                        env_name: "FL_TPA_PUBLISH",
                                        description: "Publish build upon upload",
-                                       default_value: false,
+                                       default_value: true,
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :force,
                                        env_name: "FL_TPA_FORCE",


### PR DESCRIPTION
Make app published as default. Seems to be what you want most of the time.

Any thoughts on keeping it the way it is?